### PR TITLE
グループ分けの際、近接原子に自動で割り当てられるplane bond_typeも除外するようにした。

### DIFF
--- a/molfidget/molecule.py
+++ b/molfidget/molecule.py
@@ -87,7 +87,7 @@ class Molecule:
         counter = 0
         for atom in self.atoms.values():
             for pair in atom.pairs.values():
-                if pair.bond_type == "none":
+                if pair.bond_type in ("none", "plane"): # 近接原子に自動で割り当てられるplaneも除外する
                     continue
                 if pair.atom1.elem != pair.atom2.elem:
                     continue


### PR DESCRIPTION
重なりを削るために近接原子に自動で割り当てられるplane bond_typeがあると、STL生成の時に同じグループとしてまとめられてしまうので、例えば同じ炭素についている水素2個がグループで出力されてしまっていた（H_19_20.stlみたいなグループ）。余計なファイルができるだけで実害はないのだけど、混乱するので、グループ判定の時にplane bond_typeを除外するようにした。このせいで複雑な構造の時に多少グループ分けの挙動が変わるけど、多分問題ないと思います。