### PR TITLE
Release v1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ mol.export_scene_as_colored_3mf(scene, "output.3mf")
 
 ## 配布
 
-PyPIパッケージ名: `molfidget`（バージョン: 1.1.0）
+PyPIパッケージ名: `molfidget`（バージョン: 1.2.0）
 GitHub Actionsで自動公開: `.github/workflows/pypi-publish.yml`
 
 ## 連携プロジェクト

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "molfidget"
-version = "1.1.0"
+version = "1.2.0"
 description = "A molecular modeler of 3D printable models from the MOL/PDB format."
 authors = ["Ryosuke Tajima <tajima.ryosuke@techmagic.co.jp>"]
 


### PR DESCRIPTION
## Summary
- Bump version to 1.2.0 for PyPI release

## Notes
- Tag `v1.2.0` is already pushed
- After merging, create a GitHub Release from the tag to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)